### PR TITLE
Add generic type annotations

### DIFF
--- a/snippets/generics.lqt
+++ b/snippets/generics.lqt
@@ -1,7 +1,14 @@
+let head 'a array -> 'a (
+    0 pick swap pop
+)
+
+let tail 'a array -> 'a array (
+    len 1 swap slice
+)
+
 let main -> (
-    [true false]
-        (false =) filter
-        len
-    print
-    print
+    [1 2 3] head print
+    [1 2 3] tail print
+    [true false] head print
+    [true false] tail print
 )

--- a/snippets/higher_order.lqt
+++ b/snippets/higher_order.lqt
@@ -1,9 +1,20 @@
-let applytwice int (int -> int) -> int (
+let applytwice 'a ('a -> 'a) -> 'a (
     dup rot swap call
     swap call
 )
 let square int -> int (dup *)
+let negate bool -> bool (not)
+
+let 
 
 let main -> (
-    3 (square) applytwice print
+    5 (square) applytwice print
+
+    0 11 range
+        ((square) applytwice) map
+        print
+
+    [true false true false]
+        ((negate) applytwice) map
+        print
 )

--- a/snippets/higher_order.lqt
+++ b/snippets/higher_order.lqt
@@ -1,9 +1,22 @@
-let applytwice int (int -> int) -> int (
+let applytwice 'a ('a -> 'a) -> 'a (
     dup rot swap call
     swap call
 )
 let square int -> int (dup *)
+let negate bool -> bool (not)
+
+let mapp 'a array ('a -> 'b) -> 'b array (
+    map
+)
 
 let main -> (
-    3 (square) applytwice print
+    5 (square) applytwice print
+
+    0 11 range
+        ((square) applytwice) mapp
+        print
+
+    [true false true false]
+        ((negate) applytwice) mapp
+        print
 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,10 +86,10 @@ fn main() {
                 .arg(&c_file_name)
                 .output()
                 .expect("couldn't make executable");
-            // fs::remove_file(c_file_name.clone()).expect(&format!(
-            //     "Couldn't remove intermediate c file {:?}",
-            //     c_file_name
-            // ));
+            fs::remove_file(c_file_name.clone()).expect(&format!(
+                "Couldn't remove intermediate c file {:?}",
+                c_file_name
+            ));
         }
         Err(d) => {
             diag.report(&d.loc, d.severity, &d.message, d.hint.as_deref());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,7 +85,9 @@ pub enum TypeExpressionKind {
         ins: Vec<TypeExpression>,
         outs: Vec<TypeExpression>,
     }, //Array { }
-       //Generic
+    Generic {
+        identifier: String,
+    }
        //Pattern, //TODO
 }
 
@@ -445,6 +447,16 @@ impl Parser {
                     kind: TypeExpressionKind::Function { ins, outs },
                     loc: tok.loc.clone(),
                 });
+            },
+            TokenKind::CharLiteral { value } => {
+                let type_expression = TypeExpression {
+                    kind: TypeExpressionKind::Generic {
+                        identifier: value.to_string(),
+                    },
+                    loc: tok.loc.clone(),
+                };
+                self.cursor += 1;
+                return Ok(type_expression);
             }
             _ => {
                 return Err(Diagnostic {


### PR DESCRIPTION
Adds the ability to define a function generically, using the character syntax `'c`, for example an `applytwice` function that applies a given function twice to an input:

```
let applytwice 'a ('a -> 'a) -> 'a (
    dup rot swap call
    swap call
)
```
